### PR TITLE
Added blocking socket mode option

### DIFF
--- a/configs/routeros-api.php
+++ b/configs/routeros-api.php
@@ -53,11 +53,12 @@ return [
      |
      */
 
-    'legacy'         => false, // Support of legacy login scheme (true - pre 6.43, false - post 6.43)
-    'timeout'        => 10,    // Max timeout for instantiating connection with RouterOS
-    'socket_timeout' => 30,    // Max timeout for read from RouterOS
-    'ssh_timeout'    => 30,    // Max timeout for read from RouterOS via SSH proto (for "/export" command)
-    'attempts'       => 10,    // Count of attempts to establish TCP session
-    'delay'          => 1,     // Delay between attempts in seconds
+    'legacy'            => false, // Support of legacy login scheme (true - pre 6.43, false - post 6.43)
+    'timeout'           => 10,    // Max timeout for instantiating connection with RouterOS
+    'socket_timeout'    => 30,    // Max timeout for read from RouterOS
+    'socket_blocking'   => true,  // Set blocking mode on a socket stream
+    'ssh_timeout'       => 30,    // Max timeout for read from RouterOS via SSH proto (for "/export" command)
+    'attempts'          => 10,    // Count of attempts to establish TCP session
+    'delay'             => 1,     // Delay between attempts in seconds
 
 ];

--- a/src/Config.php
+++ b/src/Config.php
@@ -97,7 +97,7 @@ class Config implements ConfigInterface
     /**
      * By default stream on blocking mode
      */
-    public const BLOCKING = true;
+    public const SOCKET_BLOCKING = true;
 
     /**
      * Max read timeout from router via SSH (in seconds)
@@ -135,7 +135,7 @@ class Config implements ConfigInterface
         'ssl_options'       => self::SSL_OPTIONS,
         'timeout'           => self::TIMEOUT,
         'socket_timeout'    => self::SOCKET_TIMEOUT,
-        'socket_blocking'   => self::BLOCKING,
+        'socket_blocking'   => self::SOCKET_BLOCKING,
         'attempts'          => self::ATTEMPTS,
         'delay'             => self::ATTEMPTS_DELAY,
         'ssh_port'          => self::SSH_PORT,

--- a/src/Config.php
+++ b/src/Config.php
@@ -90,6 +90,11 @@ class Config implements ConfigInterface
     public const SSH_PORT = 22;
 
     /**
+     * By default stream on non-blocking mode
+     */
+    public const BLOCKING = false;
+
+    /**
      * List of allowed parameters of config
      */
     public const ALLOWED = [
@@ -104,6 +109,7 @@ class Config implements ConfigInterface
         'attempts'    => 'integer', // Count of attempts to establish TCP session
         'delay'       => 'integer', // Delay between attempts in seconds
         'ssh_port'    => 'integer', // Number of SSH port
+        'blocking'    => 'boolean', // Set blocking mode on a stream
     ];
 
     /**
@@ -119,6 +125,7 @@ class Config implements ConfigInterface
         'attempts'    => self::ATTEMPTS,
         'delay'       => self::ATTEMPTS_DELAY,
         'ssh_port'    => self::SSH_PORT,
+        'blocking'    => self::BLOCKING,
     ];
 
     /**

--- a/src/SocketTrait.php
+++ b/src/SocketTrait.php
@@ -60,6 +60,11 @@ trait SocketTrait
             throw new ConnectException('Unable to establish socket session, ' . $this->socket_err_str);
         }
 
+        // Set blocking mode on a stream
+        if ($this->config('blocking') === true){
+            stream_set_blocking($socket, true);
+        }
+
         //Timeout read
         stream_set_timeout($socket, $this->config('timeout'));
 

--- a/src/Streams/ResourceStream.php
+++ b/src/Streams/ResourceStream.php
@@ -50,6 +50,11 @@ class ResourceStream implements StreamInterface
 
         $result = fread($this->stream, $length);
 
+        // Stream in blocking mode timed out
+        if(socket_get_status($this->stream)['timed_out']){
+            throw new StreamException('Stream timed out');
+        }
+
         if (false === $result) {
             throw new StreamException("Error reading $length bytes");
         }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -24,7 +24,7 @@ class ConfigTest extends TestCase
         $obj    = new Config();
         $params = $obj->getParameters();
 
-        $this->assertCount(9, $params);
+        $this->assertCount(10, $params);
         $this->assertEquals(false, $params['legacy']);
         $this->assertEquals(false, $params['ssl']);
         $this->assertEquals(10, $params['timeout']);
@@ -37,7 +37,7 @@ class ConfigTest extends TestCase
         $obj    = new Config(['timeout' => 100]);
         $params = $obj->getParameters();
 
-        $this->assertCount(9, $params);
+        $this->assertCount(10, $params);
         $this->assertEquals(100, $params['timeout']);
     }
 


### PR DESCRIPTION
This commit fix bug with socket timeout after reboot device. #36 

Setting stream to blocking mode, stream was waiting for data to become avaible on the stream for given time (stream_timeout config parameter) and then timed out. So, If we reboot device, stream timed out after stream_timeout and we can continue processing php script (reconnect after reboot need be handle manually by programmer).

In non-blocking mode, socket timeout not working (because non blocking not waiting for data to be available).

In this commit, stream is set to blocking mode defaultly. After some testing on real device, it seems fully working.

When using command which cause device is disconnected (changing wlan parameters on device connected via wlan interface), remember, when using blocking mode, socket timeout must be longer, than time when device is inaccessible. When device is inaccessible longer than is socket timeout, StreamException will be thrown.

Using longer socket timeout means, that script will be longer "waiting" for device be back online. On other hand, using longer socket timeout means, that script will be longer "waiting" for rebooted device (after reboot, socket must be reconnect manually!) or longer timeout before throw StreamException when device died during operation.

I think, this feature should by documented in readme, but I have absolutely no idea how to describe it for "non pro" users. :)
Maybe just documenting socket timeout as value while waiting for response from device (?).