### PR TITLE
Spatie - executeAsync cause early quit from loop -> execute

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -598,7 +598,7 @@ class Client implements Interfaces\ClientInterface
 
             // Run export command
             $connection->removeBash();
-            $command = $connection->executeAsync('/export' . ' ' . $arguments);
+            $command = $connection->execute('/export' . ' ' . $arguments);
 
         } catch (\Throwable $e) {
             throw new ClientException($e);


### PR DESCRIPTION
With async execute cause early quit from loop when the config is huge. 